### PR TITLE
fix: windows process permissions

### DIFF
--- a/hax/src/mem/win.rs
+++ b/hax/src/mem/win.rs
@@ -6,8 +6,7 @@ use windows::Win32::System::Diagnostics::Debug::ReadProcessMemory;
 use windows::Win32::System::Diagnostics::Debug::WriteProcessMemory;
 use windows::Win32::System::Threading::OpenProcess;
 use windows::Win32::System::Threading::PROCESS_ACCESS_RIGHTS;
-use windows::Win32::System::Threading::PROCESS_VM_READ;
-use windows::Win32::System::Threading::PROCESS_VM_WRITE;
+use windows::Win32::System::Threading::PROCESS_ALL_ACCESS;
 
 pub struct ExternalMemory {
     handle: HANDLE,
@@ -17,7 +16,7 @@ impl ExternalMemory {
     pub fn new(pid: i32) -> Self {
         let handle = unsafe {
             OpenProcess(
-                PROCESS_ACCESS_RIGHTS(PROCESS_VM_READ.0 | PROCESS_VM_WRITE.0),
+                PROCESS_ACCESS_RIGHTS(PROCESS_ALL_ACCESS.0),
                 false,
                 pid as u32,
             )


### PR DESCRIPTION
Found a small bug on Windows. If you want to read/write memory you need more than just VM_READ and VM_WRITE. This fixes it.